### PR TITLE
use poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,5 @@ pytest = "^7.2"
 black = "^22.12"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
[poetry-core](https://github.com/python-poetry/poetry-core) is intended to be a light weight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects.

Using poetry-core allows distribution packages to depend only on the build backend.