### PR TITLE
feat: Populate __source__ metadata attribute for fava

### DIFF
--- a/beancount_ing/ec.py
+++ b/beancount_ing/ec.py
@@ -108,7 +108,7 @@ class ECImporter(Importer):
 
         return True
 
-    def extract(self, filepath: str, existing_entries: Optional[data.Entries] = None):
+    def extract(self, filepath: str, existing: data.Entries = None):
         entries = []
         self._line_index = 0
 
@@ -206,8 +206,9 @@ class ECImporter(Importer):
             _read_empty_line()
 
             # Data entries
+            lines = [line.strip() for line in fd.readlines()]
             reader = csv.reader(
-                fd, delimiter=";", quoting=csv.QUOTE_MINIMAL, quotechar='"'
+                lines, delimiter=";", quoting=csv.QUOTE_MINIMAL, quotechar='"'
             )
 
             def remap(names):
@@ -224,7 +225,7 @@ class ECImporter(Importer):
             # memoize first and last transactions for balance assertion
             first_transaction = last_transaction = None
 
-            for row in reader:
+            for index, row in enumerate(reader):
                 line = dict(zip(field_names, row))
 
                 # Mark first and last transaction together with line numbers
@@ -239,6 +240,7 @@ class ECImporter(Importer):
                 currency = line["Währung_2"]
 
                 meta = data.new_metadata(filepath, self._line_index)
+                meta["__source__"] = lines[index]
 
                 amount = Amount(_format_number_de(amount), currency)
                 date = datetime.strptime(date, "%d.%m.%Y").date()


### PR DESCRIPTION
This PR adds the `__source__` metadata attribute, as specified by fava docs:
https://github.com/beancount/fava/blob/main/src/fava/help/import.md

> Set the special metadata key __source__ to display the corresponding text (CSV-row, XML-fragment, etc.) for the entry in the list of entries to import. Note that this metadata will be stripped before saving the entry to file.

Also, `extract` method signature fixed to be matching the interface: https://github.com/beancount/beangulp/blob/master/beangulp/importer.py#L105